### PR TITLE
passed var cluster NULL AND mode socket on windows

### DIFF
--- a/R/experiments.R
+++ b/R/experiments.R
@@ -108,11 +108,12 @@ performanceEstimation <- function(tasks,workflows,estTask,...) {
 cvEstimates <- function(wf,task,estTask,cluster) {
 
     ## registering (and eventually creating) the parallel backend
-    if (!missing(cluster) && getOption("parallelMap.status")=="stopped") {
+    if (!missing(cluster) && !is.null(cluster) && getOption("parallelMap.status")=="stopped") {
         if (is(cluster,"list")) do.call(parallelMap::parallelStart,cluster)
         else {
             cores <- parallel::detectCores()-1
-            parallelMap::parallelStart(mode="multicore",cpus=cores,show.info=FALSE)
+            mode <- if(.Platform$OS.type != "windows") { "multicore" } else { "socket" }
+            parallelMap::parallelStart(mode=mode,cpus=cores,show.info=FALSE)
             on.exit(parallelMap::parallelStop())
         }
         parallelMap::parallelLibrary(packages=.packages())
@@ -224,11 +225,12 @@ cvEstimates <- function(wf,task,estTask,cluster) {
 #
 hldEstimates <- function(wf,task,estTask,cluster) {
     ## registering (and eventually creating) the parallel backend
-    if (!missing(cluster) && getOption("parallelMap.status")=="stopped") {
+    if (!missing(cluster) && !is.null(cluster) && getOption("parallelMap.status")=="stopped") {
         if (is(cluster,"list")) do.call(parallelMap::parallelStart,cluster)
         else {
             cores <- parallel::detectCores()-1
-            parallelMap::parallelStart(mode="multicore",cpus=cores,show.info=FALSE)
+            mode <- if(.Platform$OS.type != "windows") { "multicore" } else { "socket" }
+            parallelMap::parallelStart(mode=mode,cpus=cores,show.info=FALSE)
             on.exit(parallelMap::parallelStop())
         }
         parallelMap::parallelLibrary(packages=.packages())
@@ -337,11 +339,12 @@ hldEstimates <- function(wf,task,estTask,cluster) {
 #
 loocvEstimates <- function(wf,task,estTask,verbose=FALSE,cluster) {
     ## registering (and eventually creating) the parallel backend
-    if (!missing(cluster) && getOption("parallelMap.status")=="stopped") {
+    if (!missing(cluster) && !is.null(cluster) && getOption("parallelMap.status")=="stopped") {
         if (is(cluster,"list")) do.call(parallelMap::parallelStart,cluster)
         else {
             cores <- parallel::detectCores()-1
-            parallelMap::parallelStart(mode="multicore",cpus=cores,show.info=FALSE)
+            mode <- if(.Platform$OS.type != "windows") { "multicore" } else { "socket" }
+            parallelMap::parallelStart(mode=mode,cpus=cores,show.info=FALSE)
             on.exit(parallelMap::parallelStop())
         }
         parallelMap::parallelLibrary(packages=.packages())
@@ -423,11 +426,12 @@ loocvEstimates <- function(wf,task,estTask,verbose=FALSE,cluster) {
 #
 bootEstimates <- function(wf,task,estTask,cluster) {
     ## registering (and eventually creating) the parallel backend
-    if (!missing(cluster) && getOption("parallelMap.status")=="stopped") {
+    if (!missing(cluster) && !is.null(cluster) && getOption("parallelMap.status")=="stopped") {
         if (is(cluster,"list")) do.call(parallelMap::parallelStart,cluster)
         else {
             cores <- parallel::detectCores()-1
-            parallelMap::parallelStart(mode="multicore",cpus=cores,show.info=FALSE)
+            mode <- if(.Platform$OS.type != "windows") { "multicore" } else { "socket" }
+            parallelMap::parallelStart(mode=mode,cpus=cores,show.info=FALSE)
             on.exit(parallelMap::parallelStop())
         }
         parallelMap::parallelLibrary(packages=.packages())
@@ -567,11 +571,12 @@ bootEstimates <- function(wf,task,estTask,cluster) {
 ## =====================================================
 mcEstimates <- function(wf, task, estTask, verbose=TRUE, cluster) {
     ## registering (and eventually creating) the parallel backend
-    if (!missing(cluster) && getOption("parallelMap.status")=="stopped") {
+    if (!missing(cluster) && !is.null(cluster) && getOption("parallelMap.status")=="stopped") {
         if (is(cluster,"list")) do.call(parallelMap::parallelStart,cluster)
         else {
             cores <- parallel::detectCores()-1
-            parallelMap::parallelStart(mode="multicore",cpus=cores,show.info=FALSE)
+            mode <- if(.Platform$OS.type != "windows") { "multicore" } else { "socket" }
+            parallelMap::parallelStart(mode=mode,cpus=cores,show.info=FALSE)
             on.exit(parallelMap::parallelStop())
         }
         parallelMap::parallelLibrary(packages=.packages())


### PR DESCRIPTION
R/experiments.R 
#### First

Actual parameter assignment of NULL is set to be 'not missing'
So if I call ... myfunction(cluster = NULL) the following (below) will correctly return FALSE

``` r
!missing(cluster) && !is.null(cluster)
```
#### Second

``` r
Browse[4]> n
Error in parallelMap::parallelStart(mode = "multicore", cpus = cores,  : 
  Multicore mode not supported on windows!
```

Change by

``` r
  mode <- if(.Platform$OS.type != "windows") { "multicore" } else { "socket" }
  parallelMap::parallelStart(mode=mode,cpus=cores,show.info=FALSE)
```
#### Note, no change is here. But I do not understand this.

``` r
> .packages()
>  RETURNS nothing !?
```
