### PR TITLE
Bugfix in CDdiagram.Nemenyi()

### DIFF
--- a/R/resultsAnalysis.R
+++ b/R/resultsAnalysis.R
@@ -276,12 +276,11 @@ CDdiagram.Nemenyi <- function(r,metric=names(r)[1]) {
     mx <- ncol(ss)
     pos <- rep(1:mxl,each=mxl) - seq(0,1,by=1/(mxl+1))[-c(1,mxl+2)]
     frees <- rep(1,mxl)
-    from <- 1
     currTill <- 0
     for(i in 1:nrow(ss)) {
-        till <- which(ss[i,i:mx])
-        till <- if (length(till)) till-1 else mx
-        if (till > currTill) {
+        till <- which(ss[i,i:mx]) + (i-1) #add i-1 to get the correct which-values since the column selection removes i-1 values
+        till <- if (length(till)>0) till[1]-1 else mx
+        if (till > i && till > currTill) {
             theLine <- min(data[wfsOrd[i],"line"],data[wfsOrd[till],"line"])
             ypos <- pos[(theLine-1)*mxl+frees[theLine]]
             frees[theLine] <- frees[theLine]+1


### PR DESCRIPTION
I would like to fix a rather tricky bug (I run into it because the plot was not showing the correct connection lines):
The statement 'till <- which(ss[i,i:mx])' (line 282 in the original file) causes a bug because it does the following: First, it takes the i-th line of the matrix and removes the first (i-1) columns from it. Next, it computes (which-call) the indices of all TRUE-values in the _remaining_ vector. However, actually required are the indices in the _original_ i-th row (respecting the removed i-1 columns), i.e. the result from which() is too small by (i-1). By adding (i-1) after the which-call, the result was correct. Additionally, I added the 'till > i' condition because it might happen otherwise that there is a bar only "connecting" one workflow (e.g. if all pairwise differences are significant)
Finally my other changes are just removing the unused variable 'from' as well as fixing the code to avoid warnings (only the first element returned by which() is actually used).
Thanks
Björn